### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.26.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -409,7 +409,6 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.26.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,7 +5,6 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.26.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,6 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.26.0 |
 
 ## Providers

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -95,7 +95,7 @@ module "dms_endpoint_s3_bucket" {
     include_op_for_full_load         = true
     parquet_timestamp_in_millisecond = true
     timestamp_column_name            = "timestamp"
-    service_access_role_arn          = join("", aws_iam_role.s3.*.arn)
+    service_access_role_arn          = join("", aws_iam_role.s3[*].arn)
   }
 
   extra_connection_attributes = ""

--- a/examples/complete/s3.tf
+++ b/examples/complete/s3.tf
@@ -13,7 +13,7 @@ resource "aws_vpc_endpoint" "s3" {
 
 module "s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "2.0.3"
+  version = "3.1.2"
 
   acl                          = "private"
   versioning_enabled           = false

--- a/examples/complete/s3.tf
+++ b/examples/complete/s3.tf
@@ -85,7 +85,7 @@ resource "aws_iam_policy" "s3" {
   count = local.enabled ? 1 : 0
 
   name   = module.s3_label.id
-  policy = join("", data.aws_iam_policy_document.s3.*.json)
+  policy = join("", data.aws_iam_policy_document.s3[*].json)
 
   tags = module.s3_label.tags
 }
@@ -94,7 +94,7 @@ resource "aws_iam_role" "s3" {
   count = local.enabled ? 1 : 0
 
   name               = module.s3_label.id
-  assume_role_policy = join("", data.aws_iam_policy_document.dms_assume_role.*.json)
+  assume_role_policy = join("", data.aws_iam_policy_document.dms_assume_role[*].json)
 
   tags = module.s3_label.tags
 }
@@ -102,6 +102,6 @@ resource "aws_iam_role" "s3" {
 resource "aws_iam_role_policy_attachment" "s3" {
   count = local.enabled ? 1 : 0
 
-  policy_arn = join("", aws_iam_policy.s3.*.arn)
-  role       = join("", aws_iam_role.s3.*.name)
+  policy_arn = join("", aws_iam_policy.s3[*].arn)
+  role       = join("", aws_iam_role.s3[*].name)
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Using the latest version of the provider since the earlier versions had many issues with DMS replication tasks.
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
       # In particular:
       # https://github.com/hashicorp/terraform-provider-aws/pull/24047
       # https://github.com/hashicorp/terraform-provider-aws/pull/23692

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -5,11 +5,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
-      # In particular:
-      # https://github.com/hashicorp/terraform-provider-aws/pull/24047
-      # https://github.com/hashicorp/terraform-provider-aws/pull/23692
-      # https://github.com/hashicorp/terraform-provider-aws/pull/13476
-      version = ">= 4.26.0"
     }
     awsutils = {
       source  = "cloudposse/awsutils"

--- a/examples/complete/vpc.tf
+++ b/examples/complete/vpc.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "cloudposse/vpc/aws"
   version = "2.1.0"
 
-  ipv4_primary_cidr_block = var.vpc_cidr_block
+  ipv4_primary_cidr_block = "172.19.0.0/16"
 
   context = module.this.context
 }
@@ -12,7 +12,7 @@ module "subnets" {
   version = "2.3.0"
 
   availability_zones   = var.availability_zones
-  vpc_id               = module.vpc.vpc_id
+  vpc_id               = local.vpc_id
   igw_id               = [module.vpc.igw_id]
   ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = false

--- a/examples/complete/vpc.tf
+++ b/examples/complete/vpc.tf
@@ -1,18 +1,18 @@
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "1.1.0"
+  version = "2.1.0"
 
-  ipv4_primary_cidr_block = "172.19.0.0/16"
+  ipv4_primary_cidr_block = var.vpc_cidr_block
 
   context = module.this.context
 }
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.0.2"
+  version = "2.3.0"
 
   availability_zones   = var.availability_zones
-  vpc_id               = local.vpc_id
+  vpc_id               = module.vpc.vpc_id
   igw_id               = [module.vpc.igw_id]
   ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = false

--- a/modules/dms-endpoint/main.tf
+++ b/modules/dms-endpoint/main.tf
@@ -120,7 +120,6 @@ resource "aws_dms_endpoint" "default" {
       encoding_type                     = lookup(var.s3_settings, "encoding_type", null)
       encryption_mode                   = lookup(var.s3_settings, "encryption_mode", null)
       external_table_definition         = lookup(var.s3_settings, "external_table_definition", null)
-      ignore_headers_row                = lookup(var.s3_settings, "ignore_headers_row", null)
       include_op_for_full_load          = lookup(var.s3_settings, "include_op_for_full_load", null)
       max_file_size                     = lookup(var.s3_settings, "max_file_size", null)
       parquet_timestamp_in_millisecond  = lookup(var.s3_settings, "parquet_timestamp_in_millisecond", null)

--- a/modules/dms-endpoint/outputs.tf
+++ b/modules/dms-endpoint/outputs.tf
@@ -1,9 +1,9 @@
 output "endpoint_id" {
-  value       = join("", aws_dms_endpoint.default.*.id)
+  value       = join("", aws_dms_endpoint.default[*].id)
   description = "Endpoint ID"
 }
 
 output "endpoint_arn" {
-  value       = join("", aws_dms_endpoint.default.*.endpoint_arn)
+  value       = join("", aws_dms_endpoint.default[*].endpoint_arn)
   description = "Endpoint ARN"
 }

--- a/modules/dms-endpoint/versions.tf
+++ b/modules/dms-endpoint/versions.tf
@@ -5,11 +5,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
-      # In particular:
-      # https://github.com/hashicorp/terraform-provider-aws/pull/24047
-      # https://github.com/hashicorp/terraform-provider-aws/pull/23692
-      # https://github.com/hashicorp/terraform-provider-aws/pull/13476
-      version = ">= 4.26.0"
     }
   }
 }

--- a/modules/dms-endpoint/versions.tf
+++ b/modules/dms-endpoint/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Using the latest version of the provider since the earlier versions had many issues with DMS replication tasks.
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
       # In particular:
       # https://github.com/hashicorp/terraform-provider-aws/pull/24047
       # https://github.com/hashicorp/terraform-provider-aws/pull/23692

--- a/modules/dms-event-subscription/outputs.tf
+++ b/modules/dms-event-subscription/outputs.tf
@@ -1,4 +1,4 @@
 output "event_subscription_arn" {
-  value       = join("", aws_dms_event_subscription.default.*.arn)
+  value       = join("", aws_dms_event_subscription.default[*].arn)
   description = "Event subscription ARN"
 }

--- a/modules/dms-event-subscription/versions.tf
+++ b/modules/dms-event-subscription/versions.tf
@@ -5,11 +5,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
-      # In particular:
-      # https://github.com/hashicorp/terraform-provider-aws/pull/24047
-      # https://github.com/hashicorp/terraform-provider-aws/pull/23692
-      # https://github.com/hashicorp/terraform-provider-aws/pull/13476
-      version = ">= 4.26.0"
     }
   }
 }

--- a/modules/dms-event-subscription/versions.tf
+++ b/modules/dms-event-subscription/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Using the latest version of the provider since the earlier versions had many issues with DMS replication tasks.
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
       # In particular:
       # https://github.com/hashicorp/terraform-provider-aws/pull/24047
       # https://github.com/hashicorp/terraform-provider-aws/pull/23692

--- a/modules/dms-iam/main.tf
+++ b/modules/dms-iam/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled   = module.this.enabled
-  partition = join("", data.aws_partition.current.*.partition)
+  partition = join("", data.aws_partition.current[*].partition)
 }
 
 data "aws_partition" "current" {
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "dms_assume_role" {
 resource "aws_iam_role" "dms_redshift_s3" {
   count = local.enabled ? 1 : 0
 
-  assume_role_policy = join("", data.aws_iam_policy_document.dms_assume_role.*.json)
+  assume_role_policy = join("", data.aws_iam_policy_document.dms_assume_role[*].json)
   name               = "dms-access-for-endpoint"
 
   tags = module.this.tags
@@ -44,13 +44,13 @@ resource "aws_iam_role_policy_attachment" "dms_redshift_s3" {
   count = local.enabled ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role"
-  role       = join("", aws_iam_role.dms_redshift_s3.*.name)
+  role       = join("", aws_iam_role.dms_redshift_s3[*].name)
 }
 
 resource "aws_iam_role" "dms_cloudwatch_logs" {
   count = local.enabled ? 1 : 0
 
-  assume_role_policy = join("", data.aws_iam_policy_document.dms_assume_role.*.json)
+  assume_role_policy = join("", data.aws_iam_policy_document.dms_assume_role[*].json)
   name               = "dms-cloudwatch-logs-role"
 
   tags = module.this.tags
@@ -60,13 +60,13 @@ resource "aws_iam_role_policy_attachment" "dms_cloudwatch_logs" {
   count = local.enabled ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole"
-  role       = join("", aws_iam_role.dms_cloudwatch_logs.*.name)
+  role       = join("", aws_iam_role.dms_cloudwatch_logs[*].name)
 }
 
 resource "aws_iam_role" "dms_vpc_management" {
   count = local.enabled ? 1 : 0
 
-  assume_role_policy = join("", data.aws_iam_policy_document.dms_assume_role.*.json)
+  assume_role_policy = join("", data.aws_iam_policy_document.dms_assume_role[*].json)
   name               = "dms-vpc-role"
 
   tags = module.this.tags
@@ -76,5 +76,5 @@ resource "aws_iam_role_policy_attachment" "amazon_dms_vpc_management" {
   count = local.enabled ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
-  role       = join("", aws_iam_role.dms_vpc_management.*.name)
+  role       = join("", aws_iam_role.dms_vpc_management[*].name)
 }

--- a/modules/dms-iam/outputs.tf
+++ b/modules/dms-iam/outputs.tf
@@ -1,14 +1,14 @@
 output "dms_redshift_s3_role_arn" {
-  value       = join("", aws_iam_role.dms_redshift_s3.*.arn)
+  value       = join("", aws_iam_role.dms_redshift_s3[*].arn)
   description = "DMS Redshift S3 role ARN"
 }
 
 output "dms_cloudwatch_logs_role_arn" {
-  value       = join("", aws_iam_role.dms_cloudwatch_logs.*.arn)
+  value       = join("", aws_iam_role.dms_cloudwatch_logs[*].arn)
   description = "DMS CloudWatch Logs role ARN"
 }
 
 output "dms_vpc_management_role_arn" {
-  value       = join("", aws_iam_role.dms_vpc_management.*.arn)
+  value       = join("", aws_iam_role.dms_vpc_management[*].arn)
   description = "DMS VPC management role ARN"
 }

--- a/modules/dms-iam/versions.tf
+++ b/modules/dms-iam/versions.tf
@@ -5,11 +5,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
-      # In particular:
-      # https://github.com/hashicorp/terraform-provider-aws/pull/24047
-      # https://github.com/hashicorp/terraform-provider-aws/pull/23692
-      # https://github.com/hashicorp/terraform-provider-aws/pull/13476
-      version = ">= 4.26.0"
     }
   }
 }

--- a/modules/dms-iam/versions.tf
+++ b/modules/dms-iam/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Using the latest version of the provider since the earlier versions had many issues with DMS replication tasks.
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
       # In particular:
       # https://github.com/hashicorp/terraform-provider-aws/pull/24047
       # https://github.com/hashicorp/terraform-provider-aws/pull/23692

--- a/modules/dms-replication-instance/main.tf
+++ b/modules/dms-replication-instance/main.tf
@@ -18,7 +18,7 @@ resource "aws_dms_replication_instance" "default" {
   preferred_maintenance_window = var.preferred_maintenance_window
   publicly_accessible          = var.publicly_accessible
   replication_instance_class   = var.replication_instance_class
-  replication_subnet_group_id  = join("", aws_dms_replication_subnet_group.default.*.id)
+  replication_subnet_group_id  = join("", aws_dms_replication_subnet_group.default[*].id)
   vpc_security_group_ids       = var.vpc_security_group_ids
 
   tags = module.this.tags

--- a/modules/dms-replication-instance/outputs.tf
+++ b/modules/dms-replication-instance/outputs.tf
@@ -1,9 +1,9 @@
 output "replication_instance_id" {
-  value       = join("", aws_dms_replication_instance.default.*.replication_instance_id)
+  value       = join("", aws_dms_replication_instance.default[*].replication_instance_id)
   description = "Replication instance ID"
 }
 
 output "replication_instance_arn" {
-  value       = join("", aws_dms_replication_instance.default.*.replication_instance_arn)
+  value       = join("", aws_dms_replication_instance.default[*].replication_instance_arn)
   description = "Replication instance ARN"
 }

--- a/modules/dms-replication-instance/versions.tf
+++ b/modules/dms-replication-instance/versions.tf
@@ -5,11 +5,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
-      # In particular:
-      # https://github.com/hashicorp/terraform-provider-aws/pull/24047
-      # https://github.com/hashicorp/terraform-provider-aws/pull/23692
-      # https://github.com/hashicorp/terraform-provider-aws/pull/13476
-      version = ">= 4.26.0"
     }
   }
 }

--- a/modules/dms-replication-instance/versions.tf
+++ b/modules/dms-replication-instance/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Using the latest version of the provider since the earlier versions had many issues with DMS replication tasks.
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
       # In particular:
       # https://github.com/hashicorp/terraform-provider-aws/pull/24047
       # https://github.com/hashicorp/terraform-provider-aws/pull/23692

--- a/modules/dms-replication-task/outputs.tf
+++ b/modules/dms-replication-task/outputs.tf
@@ -1,9 +1,9 @@
 output "replication_task_id" {
-  value       = join("", aws_dms_replication_task.default.*.id)
+  value       = join("", aws_dms_replication_task.default[*].id)
   description = "Replication task ID"
 }
 
 output "replication_task_arn" {
-  value       = join("", aws_dms_replication_task.default.*.replication_task_arn)
+  value       = join("", aws_dms_replication_task.default[*].replication_task_arn)
   description = "Replication task ARN"
 }

--- a/modules/dms-replication-task/versions.tf
+++ b/modules/dms-replication-task/versions.tf
@@ -5,11 +5,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
-      # In particular:
-      # https://github.com/hashicorp/terraform-provider-aws/pull/24047
-      # https://github.com/hashicorp/terraform-provider-aws/pull/23692
-      # https://github.com/hashicorp/terraform-provider-aws/pull/13476
-      version = ">= 4.26.0"
     }
   }
 }

--- a/modules/dms-replication-task/versions.tf
+++ b/modules/dms-replication-task/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Using the latest version of the provider since the earlier versions had many issues with DMS replication tasks.
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
       # In particular:
       # https://github.com/hashicorp/terraform-provider-aws/pull/24047
       # https://github.com/hashicorp/terraform-provider-aws/pull/23692

--- a/versions.tf
+++ b/versions.tf
@@ -5,11 +5,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
-      # In particular:
-      # https://github.com/hashicorp/terraform-provider-aws/pull/24047
-      # https://github.com/hashicorp/terraform-provider-aws/pull/23692
-      # https://github.com/hashicorp/terraform-provider-aws/pull/13476
-      version = ">= 4.26.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Using the latest version of the provider since the earlier versions had many issues with DMS replication tasks.
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
       # In particular:
       # https://github.com/hashicorp/terraform-provider-aws/pull/24047
       # https://github.com/hashicorp/terraform-provider-aws/pull/23692


### PR DESCRIPTION
## what

Support AWS Provider V5
`ignore_headers_row` arg deprecated
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
