### PR TITLE
feat: add subnet group id output

### DIFF
--- a/examples/complete/aurora-postgres.tf
+++ b/examples/complete/aurora-postgres.tf
@@ -4,8 +4,8 @@ module "aurora_postgres_cluster" {
 
   engine                               = "aurora-postgresql"
   engine_mode                          = "provisioned"
-  engine_version                       = "13.4"
-  cluster_family                       = "aurora-postgresql13"
+  engine_version                       = "15.4"
+  cluster_family                       = "aurora-postgresql15"
   cluster_size                         = 1
   admin_user                           = var.admin_user
   admin_password                       = var.admin_password

--- a/modules/dms-replication-instance/outputs.tf
+++ b/modules/dms-replication-instance/outputs.tf
@@ -7,3 +7,8 @@ output "replication_instance_arn" {
   value       = join("", aws_dms_replication_instance.default[*].replication_instance_arn)
   description = "Replication instance ARN"
 }
+
+output "subnet_group_id" {
+  value       = join("", aws_dms_replication_subnet_group.default[*].replication_subnet_group_id)
+  description = "Replication subnet group ID"
+}


### PR DESCRIPTION
## what

* Adds a output to the replication instance submodule for the subnet group ID

## why

* This is needed when creating a replication instance AND a serverless config via `aws_dms_replication_config`

## references

* N/A
