### PR TITLE
feat: dms serverless replication

### DIFF
--- a/modules/dms-serverless-replication-config/README.md
+++ b/modules/dms-serverless-replication-config/README.md
@@ -1,0 +1,217 @@
+# dms-serverless-replication-config
+
+Terraform module to provision DMS Serverless Replication configuration resource. Because this is serverless, a DMS replication instance is **NOT** needed at all.
+
+## Usage
+
+```hcl
+module "dms_iam" {
+  source = "cloudposse/dms/aws//modules/dms-iam"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  context = module.this.context
+}
+
+module "vpc" {
+  source = "cloudposse/vpc/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  ipv4_primary_cidr_block = "172.19.0.0/16"
+
+  context = module.this.context
+}
+
+module "subnets" {
+  source = "cloudposse/dynamic-subnets/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  availability_zones   = ["us-east-2a", "us-east-2b"]
+  vpc_id               = local.vpc_id
+  igw_id               = [module.vpc.igw_id]
+  ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
+  nat_gateway_enabled  = false
+  nat_instance_enabled = false
+
+  context = module.this.context
+}
+
+module "aurora_postgres_cluster" {
+  source = "cloudposse/rds-cluster/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  engine                               = "aurora-postgresql"
+  engine_mode                          = "provisioned"
+  engine_version                       = "13.4"
+  cluster_family                       = "aurora-postgresql13"
+  cluster_size                         = 1
+  admin_user                           = "admin_user"
+  admin_password                       = "admin_password"
+  db_name                              = "postgres"
+  db_port                              = 5432
+  instance_type                        = "db.t3.medium"
+  vpc_id                               = module.vpc.vpc_id
+  subnets                              = module.subnets.private_subnet_ids
+  security_groups                      = [module.vpc.vpc_default_security_group_id]
+  deletion_protection                  = false
+  autoscaling_enabled                  = false
+  storage_encrypted                    = false
+  intra_security_group_traffic_enabled = false
+  skip_final_snapshot                  = true
+  enhanced_monitoring_role_enabled     = false
+  iam_database_authentication_enabled  = false
+
+  cluster_parameters = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_replication_slots"
+      value        = "10"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_worker_processes"
+      value        = "8"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_logical_replication_workers"
+      value        = "10"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_parallel_workers"
+      value        = "8"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_parallel_workers"
+      value        = "8"
+      apply_method = "pending-reboot"
+    }
+  ]
+
+  context = module.this.context
+}
+
+module "dms_endpoint_aurora_postgres" {
+  source = "cloudposse/dms/aws//modules/dms-endpoint"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  endpoint_type                   = "source"
+  engine_name                     = "aurora-postgresql"
+  server_name                     = module.aurora_postgres_cluster.reader_endpoint
+  database_name                   = "postgres"
+  port                            = 5432
+  username                        = "admin_user"
+  password                        = "admin_password"
+  extra_connection_attributes     = ""
+  secrets_manager_access_role_arn = null
+  secrets_manager_arn             = null
+  ssl_mode                        = "none"
+
+  attributes = ["source"]
+  context    = module.this.context
+}
+
+# Upgrades to AWS DMS versions 3.4.7 and higher require that you configure AWS DMS to use VPC endpoints or use public routes.
+# This requirement applies to source and target endpoints for these data stores: S3, Kinesis, Secrets Manager, DynamoDB, Amazon Redshift, and OpenSearch Service.
+resource "aws_vpc_endpoint" "s3" {
+  vpc_endpoint_type = "Gateway"
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  route_table_ids   = module.subnets.private_route_table_ids
+
+  tags = module.this.tags
+}
+
+module "s3_bucket" {
+  source = "cloudposse/s3-bucket/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  acl                          = "private"
+  versioning_enabled           = false
+  allow_encrypted_uploads_only = false
+  allow_ssl_requests_only      = false
+  force_destroy                = true
+  block_public_acls            = true
+  block_public_policy          = true
+  ignore_public_acls           = true
+  restrict_public_buckets      = true
+
+  context = module.this.context
+}
+
+module "dms_endpoint_s3_bucket" {
+  source = "cloudposse/dms/aws//modules/dms-endpoint"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  endpoint_type = "target"
+  engine_name   = "s3"
+
+  s3_settings = {
+    bucket_name                      = module.s3_bucket.bucket_id
+    bucket_folder                    = null
+    cdc_inserts_only                 = false
+    csv_row_delimiter                = " "
+    csv_delimiter                    = ","
+    data_format                      = "parquet"
+    compression_type                 = "GZIP"
+    date_partition_delimiter         = "NONE"
+    date_partition_enabled           = true
+    date_partition_sequence          = "YYYYMMDD"
+    include_op_for_full_load         = true
+    parquet_timestamp_in_millisecond = true
+    timestamp_column_name            = "timestamp"
+    service_access_role_arn          = aws_iam_role.s3.arn
+  }
+
+  extra_connection_attributes = ""
+
+  attributes = ["target"]
+  context    = module.this.context
+}
+
+module "dms_replication_task" {
+  source = "cloudposse/dms/aws//modules/dms-replication-task"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  replication_type = "full-load-and-cdc"
+  source_endpoint_arn = module.dms_endpoint_aurora_postgres.endpoint_arn
+  target_endpoint_arn = module.dms_endpoint_s3_bucket.endpoint_arn
+
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TaskSettings.html
+  replication_settings = file("${path.module}/config/replication-task-settings.json")
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.html
+  table_mappings = file("${path.module}/config/replication-task-table-mappings.json")
+
+  # Compute & Network Configurations
+  replication_min_capacity_units = 2
+  replication_max_capacity_units = 8
+  vpc_security_group_ids = []
+  subnet_ids = []
+
+  context = module.this.context
+  attributes = ["serverless"]
+}
+```
+
+## Notes
+
+[AWS DMS Serverless](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Serverless.html)
+The initial resource creation may take >20 minutes. Check out this diagram to see the definition of each status in hte lifecycle: [AWS DMS Serverless Components](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Serverless.Components.html)

--- a/modules/dms-serverless-replication-config/context.tf
+++ b/modules/dms-serverless-replication-config/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/dms-serverless-replication-config/main.tf
+++ b/modules/dms-serverless-replication-config/main.tf
@@ -1,0 +1,37 @@
+locals {
+  enabled = module.this.enabled
+}
+
+resource "aws_dms_replication_config" "default" {
+  count = local.enabled ? 1 : 0
+
+  replication_config_identifier = module.this.id
+  resource_identifier           = module.this.id
+  replication_type              = var.replication_type
+  source_endpoint_arn           = var.source_endpoint_arn
+  target_endpoint_arn           = var.target_endpoint_arn
+  replication_settings          = var.replication_settings
+  table_mappings                = var.table_mappings
+  start_replication             = var.start_replication
+
+  compute_config {
+    vpc_security_group_ids       = var.vpc_security_group_ids # required in the main
+    replication_subnet_group_id  = join("", aws_dms_replication_subnet_group.default[*].id)
+    max_capacity_units           = var.replication_max_capacity_units
+    min_capacity_units           = var.replication_min_capacity_units
+    preferred_maintenance_window = var.replication_maintenance_window
+    multi_az                     = var.multi_az
+  }
+
+  tags = module.this.tags
+}
+
+resource "aws_dms_replication_subnet_group" "default" {
+  count = local.enabled ? 1 : 0
+
+  replication_subnet_group_id          = module.this.id
+  replication_subnet_group_description = format("%s DMS Serverless Replication subnet group", module.this.id)
+  subnet_ids                           = var.subnet_ids
+
+  tags = module.this.tags
+}

--- a/modules/dms-serverless-replication-config/outputs.tf
+++ b/modules/dms-serverless-replication-config/outputs.tf
@@ -1,0 +1,4 @@
+output "replication_config_arn" {
+  value       = join("", aws_dms_replication_config.default[*].arn)
+  description = "DMS Serverless Replication configuration ARN"
+}

--- a/modules/dms-serverless-replication-config/variables.tf
+++ b/modules/dms-serverless-replication-config/variables.tf
@@ -1,0 +1,89 @@
+variable "start_replication" {
+  type        = bool
+  description = "If set to `true`, the created replication will be started automatically"
+  default     = true
+}
+
+variable "replication_type" {
+  type        = string
+  description = "The replication type for the migration. Can be one of `full-load`, `cdc`, `full-load-and-cdc`"
+  default     = "full-load-and-cdc"
+}
+
+variable "source_endpoint_arn" {
+  type        = string
+  description = "The Amazon Resource Name (ARN) string that uniquely identifies the source endpoint"
+}
+
+variable "target_endpoint_arn" {
+  type        = string
+  description = "The Amazon Resource Name (ARN) string that uniquely identifies the target endpoint"
+}
+
+variable "table_mappings" {
+  type        = string
+  description = "An escaped JSON string that contains the table mappings. See https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.html for more details"
+}
+
+variable "replication_settings" {
+  type        = string
+  description = "An escaped JSON string that contains the task settings. See https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TaskSettings.html for more details"
+  default     = null
+}
+
+variable "replication_max_capacity_units" {
+  type        = string
+  description = <<EOT
+  Specifies the maximum value of the DMS capacity units (DCUs) for which a given DMS Serverless replication can be provisioned.
+  A single DCU is 2GB of RAM, with 2 DCUs as the minimum value allowed.
+  The list of valid DCU values includes 2, 4, 8, 16, 32, 64, 128, 192, 256, and 384.
+  EOT
+  default     = "16"
+
+  validation {
+    condition     = can(regex("^(2|4|8|16|32|64|128|192|256|384)$", var.replication_max_capacity_units))
+    error_message = "Invalid replication_max_capacity_units. Must be one of 2, 4, 8, 16, 32, 64, 128, 192, 256, 384."
+  }
+}
+
+variable "replication_min_capacity_units" {
+  type        = string
+  description = <<EOT
+  Specifies the minimum value of the DMS capacity units (DCUs) for which a given DMS Serverless replication can be provisioned.
+  The list of valid DCU values includes 2, 4, 8, 16, 32, 64, 128, 192, 256, and 384.
+  If this value isn't set DMS scans the current activity of available source tables to identify an optimum setting for this parameter.
+  EOT
+  default     = "2"
+
+  validation {
+    condition     = can(regex("^(2|4|8|16|32|64|128|192|256|384)$", var.replication_min_capacity_units))
+    error_message = "Invalid replication_min_capacity_units. Must be one of 2, 4, 8, 16, 32, 64, 128, 192, 256, 384."
+  }
+}
+
+variable "replication_maintenance_window" {
+  type        = string
+  description = <<EOT
+  The weekly time range during which system maintenance can occur.
+  Format: ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC).
+  EOT
+  default     = "sun:23:45-mon:00:30"
+}
+
+variable "multi_az" {
+  type        = bool
+  description = "Specifies whether the replication instance is a Multi-AZ deployment"
+  default     = true
+}
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "Specifies the virtual private cloud (VPC) security group to use with the DMS Serverless replication. The VPC security group must work with the VPC containing the replication."
+  default     = []
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of the EC2 subnet IDs for the replication subnet group"
+  default     = []
+}

--- a/modules/dms-serverless-replication-config/versions.tf
+++ b/modules/dms-serverless-replication-config/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## what

Something @Gowiem was previously working on, DMS Serverless replication, which is the same as the migration replication task but doesn't need an instance because it's serverless.

Thought it would be a good addition here with the other resources. 

I've added the module and also an example within the `examples/complete` using the DBs created there as well.

## references

https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Serverless.html
