### PR TITLE
fix(endpoint): make map_long_varchar_as a string

### DIFF
--- a/modules/dms-endpoint/variables.tf
+++ b/modules/dms-endpoint/variables.tf
@@ -120,7 +120,7 @@ variable "postgres_settings" {
     heartbeat_schema             = optional(string, false)
     map_boolean_as_boolean       = optional(bool, false)
     map_jsonb_as_clob            = optional(bool, false)
-    map_long_varchar_as          = optional(bool, false)
+    map_long_varchar_as          = optional(string, "wstring")
     max_file_size                = optional(number, null)
     plugin_name                  = optional(string, null)
     slot_name                    = optional(string, null)


### PR DESCRIPTION
## what

Changes the attribute `map_long_varchar_as` to a string parameter

## why

DMS expects the value to be one of `wstring` (default), `clob` or `nclob` , but Terraform's docs are misleading and describe it as "if set to TRUE...", the code actually checks for a string value

## references

* [DMS API Reference](https://docs.aws.amazon.com/dms/latest/APIReference/API_PostgreSQLSettings.html#DMS-Type-PostgreSQLSettings-MapLongVarcharAs)
* [Terraform AWS Provider source code](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/dms/endpoint.go#L407-L410)