### PR TITLE
remove deprecated s3 settings from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 -->
 
-Terraform modules for provisioning and managing AWS [DMS](https://aws.amazon.com/dms/) resources. 
+Terraform modules for provisioning and managing AWS [DMS](https://aws.amazon.com/dms/) resources.
 
 The following DMS resources are supported:
 
@@ -250,37 +250,6 @@ For automated tests of the example using [bats](https://github.com/bats-core/bat
     context    = module.this.context
   }
 
-  module "dms_endpoint_s3_bucket" {
-    source = "cloudposse/dms/aws//modules/dms-endpoint"
-    # Cloud Posse recommends pinning every module to a specific version
-    # version     = "x.x.x"
-
-    endpoint_type = "target"
-    engine_name   = "s3"
-
-    s3_settings = {
-      bucket_name                      = module.s3_bucket.bucket_id
-      bucket_folder                    = null
-      cdc_inserts_only                 = false
-      csv_row_delimiter                = " "
-      csv_delimiter                    = ","
-      data_format                      = "parquet"
-      compression_type                 = "GZIP"
-      date_partition_delimiter         = "NONE"
-      date_partition_enabled           = true
-      date_partition_sequence          = "YYYYMMDD"
-      include_op_for_full_load         = true
-      parquet_timestamp_in_millisecond = true
-      timestamp_column_name            = "timestamp"
-      service_access_role_arn          = aws_iam_role.s3.arn
-    }
-
-    extra_connection_attributes = ""
-
-    attributes = ["target"]
-    context    = module.this.context
-  }
-
   module "dms_replication_task" {
     source = "cloudposse/dms/aws//modules/dms-replication-task"
     # Cloud Posse recommends pinning every module to a specific version
@@ -306,7 +275,7 @@ For automated tests of the example using [bats](https://github.com/bats-core/bat
     sqs_dlq_enabled                        = false
     fifo_topic                             = false
     fifo_queue_enabled                     = false
-    encryption_enabled                     = false  
+    encryption_enabled                     = false
 
     allowed_aws_services_for_sns_published = [
       "cloudwatch.amazonaws.com",
@@ -365,14 +334,14 @@ For automated tests of the example using [bats](https://github.com/bats-core/bat
   }
 ```
 
-__NOTE:__  If a replication task is in "Failed" state (for any reason, e.g. network connectivity issues, database table issues, configuration issues), 
-it can't be destroyed with Terraform (but can be updated). 
+__NOTE:__  If a replication task is in "Failed" state (for any reason, e.g. network connectivity issues, database table issues, configuration issues),
+it can't be destroyed with Terraform (but can be updated).
 The task needs to be updated/fixed and moved to any other state like "Running", "Stopped", "Starting", "Ready", etc.
 
-You can monitor the progress of your task by checking the task status and by monitoring the task's control table. 
-The task status indicates the condition of an AWS DMS task and its associated resources. 
-It includes such indications as if the task is being created, starting, running, stopped, or failed. 
-It also includes the current state of the tables that the task is migrating, such as if a full load of a table has begun 
+You can monitor the progress of your task by checking the task status and by monitoring the task's control table.
+The task status indicates the condition of an AWS DMS task and its associated resources.
+It includes such indications as if the task is being created, starting, running, stopped, or failed.
+It also includes the current state of the tables that the task is migrating, such as if a full load of a table has begun
 or is in progress and details such as the number of inserts, deletes, and updates have occurred for the table.
 
 Refer to [Monitoring DMS Task Status](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Monitoring.html#CHAP_Tasks.Status) for more information.

--- a/README.yaml
+++ b/README.yaml
@@ -67,7 +67,7 @@ references:
 
 # Short description of this project
 description: |-
-  Terraform modules for provisioning and managing AWS [DMS](https://aws.amazon.com/dms/) resources. 
+  Terraform modules for provisioning and managing AWS [DMS](https://aws.amazon.com/dms/) resources.
 
   The following DMS resources are supported:
 
@@ -265,37 +265,6 @@ examples: |2-
       context    = module.this.context
     }
 
-    module "dms_endpoint_s3_bucket" {
-      source = "cloudposse/dms/aws//modules/dms-endpoint"
-      # Cloud Posse recommends pinning every module to a specific version
-      # version     = "x.x.x"
-
-      endpoint_type = "target"
-      engine_name   = "s3"
-
-      s3_settings = {
-        bucket_name                      = module.s3_bucket.bucket_id
-        bucket_folder                    = null
-        cdc_inserts_only                 = false
-        csv_row_delimiter                = " "
-        csv_delimiter                    = ","
-        data_format                      = "parquet"
-        compression_type                 = "GZIP"
-        date_partition_delimiter         = "NONE"
-        date_partition_enabled           = true
-        date_partition_sequence          = "YYYYMMDD"
-        include_op_for_full_load         = true
-        parquet_timestamp_in_millisecond = true
-        timestamp_column_name            = "timestamp"
-        service_access_role_arn          = aws_iam_role.s3.arn
-      }
-
-      extra_connection_attributes = ""
-
-      attributes = ["target"]
-      context    = module.this.context
-    }
-
     module "dms_replication_task" {
       source = "cloudposse/dms/aws//modules/dms-replication-task"
       # Cloud Posse recommends pinning every module to a specific version
@@ -321,7 +290,7 @@ examples: |2-
       sqs_dlq_enabled                        = false
       fifo_topic                             = false
       fifo_queue_enabled                     = false
-      encryption_enabled                     = false  
+      encryption_enabled                     = false
 
       allowed_aws_services_for_sns_published = [
         "cloudwatch.amazonaws.com",
@@ -380,14 +349,14 @@ examples: |2-
     }
   ```
 
-  __NOTE:__  If a replication task is in "Failed" state (for any reason, e.g. network connectivity issues, database table issues, configuration issues), 
-  it can't be destroyed with Terraform (but can be updated). 
+  __NOTE:__  If a replication task is in "Failed" state (for any reason, e.g. network connectivity issues, database table issues, configuration issues),
+  it can't be destroyed with Terraform (but can be updated).
   The task needs to be updated/fixed and moved to any other state like "Running", "Stopped", "Starting", "Ready", etc.
 
-  You can monitor the progress of your task by checking the task status and by monitoring the task's control table. 
-  The task status indicates the condition of an AWS DMS task and its associated resources. 
-  It includes such indications as if the task is being created, starting, running, stopped, or failed. 
-  It also includes the current state of the tables that the task is migrating, such as if a full load of a table has begun 
+  You can monitor the progress of your task by checking the task status and by monitoring the task's control table.
+  The task status indicates the condition of an AWS DMS task and its associated resources.
+  It includes such indications as if the task is being created, starting, running, stopped, or failed.
+  It also includes the current state of the tables that the task is migrating, such as if a full load of a table has begun
   or is in progress and details such as the number of inserts, deletes, and updates have occurred for the table.
 
   Refer to [Monitoring DMS Task Status](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Monitoring.html#CHAP_Tasks.Status) for more information.

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -75,40 +75,6 @@ module "dms_endpoint_aurora_postgres" {
   ]
 }
 
-module "dms_endpoint_s3_bucket" {
-  source = "../../modules/dms-endpoint"
-
-  endpoint_type = "target"
-  engine_name   = "s3"
-
-  s3_settings = {
-    bucket_name                      = module.s3_bucket.bucket_id
-    bucket_folder                    = null
-    cdc_inserts_only                 = false
-    csv_row_delimiter                = " "
-    csv_delimiter                    = ","
-    data_format                      = "parquet"
-    compression_type                 = "GZIP"
-    date_partition_delimiter         = "NONE"
-    date_partition_enabled           = true
-    date_partition_sequence          = "YYYYMMDD"
-    include_op_for_full_load         = true
-    parquet_timestamp_in_millisecond = true
-    timestamp_column_name            = "timestamp"
-    service_access_role_arn          = join("", aws_iam_role.s3[*].arn)
-  }
-
-  extra_connection_attributes = ""
-
-  attributes = ["target"]
-  context    = module.this.context
-
-  depends_on = [
-    aws_iam_role.s3,
-    module.s3_bucket
-  ]
-}
-
 resource "time_sleep" "wait_for_dms_endpoints" {
   count = local.enabled ? 1 : 0
 

--- a/modules/dms-endpoint/README.md
+++ b/modules/dms-endpoint/README.md
@@ -150,35 +150,4 @@ module "s3_bucket" {
 
   context = module.this.context
 }
-
-module "dms_endpoint_s3_bucket" {
-  source = "cloudposse/dms/aws//modules/dms-endpoint"
-  # Cloud Posse recommends pinning every module to a specific version
-  # version     = "x.x.x"
-
-  endpoint_type = "target"
-  engine_name   = "s3"
-
-  s3_settings = {
-    bucket_name                      = module.s3_bucket.bucket_id
-    bucket_folder                    = null
-    cdc_inserts_only                 = false
-    csv_row_delimiter                = " "
-    csv_delimiter                    = ","
-    data_format                      = "parquet"
-    compression_type                 = "GZIP"
-    date_partition_delimiter         = "NONE"
-    date_partition_enabled           = true
-    date_partition_sequence          = "YYYYMMDD"
-    include_op_for_full_load         = true
-    parquet_timestamp_in_millisecond = true
-    timestamp_column_name            = "timestamp"
-    service_access_role_arn          = aws_iam_role.s3.arn
-  }
-
-  extra_connection_attributes = ""
-
-  attributes = ["target"]
-  context    = module.this.context
-}
 ```

--- a/modules/dms-endpoint/main.tf
+++ b/modules/dms-endpoint/main.tf
@@ -115,47 +115,5 @@ resource "aws_dms_endpoint" "default" {
     }
   }
 
-  dynamic "s3_settings" {
-    for_each = var.s3_settings != null ? [true] : []
-    content {
-      bucket_name                                 = var.s3_settings["bucket_name"]
-      add_column_name                             = lookup(var.s3_settings, "add_column_name", null)
-      bucket_folder                               = lookup(var.s3_settings, "bucket_folder", null)
-      canned_acl_for_objects                      = lookup(var.s3_settings, "canned_acl_for_objects", null)
-      cdc_inserts_and_updates                     = lookup(var.s3_settings, "cdc_inserts_and_updates", null)
-      cdc_inserts_only                            = lookup(var.s3_settings, "cdc_inserts_only", null)
-      cdc_max_batch_interval                      = lookup(var.s3_settings, "cdc_max_batch_interval", null)
-      cdc_min_file_size                           = lookup(var.s3_settings, "cdc_min_file_size", null)
-      cdc_path                                    = lookup(var.s3_settings, "cdc_path", null)
-      compression_type                            = lookup(var.s3_settings, "compression_type", null)
-      csv_delimiter                               = lookup(var.s3_settings, "csv_delimiter", null)
-      csv_no_sup_value                            = lookup(var.s3_settings, "csv_no_sup_value", null)
-      csv_null_value                              = lookup(var.s3_settings, "csv_null_value", null)
-      csv_row_delimiter                           = lookup(var.s3_settings, "csv_row_delimiter", null)
-      data_format                                 = lookup(var.s3_settings, "data_format", null)
-      data_page_size                              = lookup(var.s3_settings, "data_page_size", null)
-      date_partition_delimiter                    = lookup(var.s3_settings, "date_partition_delimiter", null)
-      date_partition_enabled                      = lookup(var.s3_settings, "date_partition_enabled", null)
-      date_partition_sequence                     = lookup(var.s3_settings, "date_partition_sequence", null)
-      dict_page_size_limit                        = lookup(var.s3_settings, "dict_page_size_limit", null)
-      enable_statistics                           = lookup(var.s3_settings, "enable_statistics", null)
-      encoding_type                               = lookup(var.s3_settings, "encoding_type", null)
-      encryption_mode                             = lookup(var.s3_settings, "encryption_mode", null)
-      external_table_definition                   = lookup(var.s3_settings, "external_table_definition", null)
-      include_op_for_full_load                    = lookup(var.s3_settings, "include_op_for_full_load", null)
-      max_file_size                               = lookup(var.s3_settings, "max_file_size", null)
-      parquet_timestamp_in_millisecond            = lookup(var.s3_settings, "parquet_timestamp_in_millisecond", null)
-      parquet_version                             = lookup(var.s3_settings, "parquet_version", null)
-      preserve_transactions                       = lookup(var.s3_settings, "preserve_transactions", null)
-      rfc_4180                                    = lookup(var.s3_settings, "rfc_4180", null)
-      row_group_length                            = lookup(var.s3_settings, "row_group_length", null)
-      server_side_encryption_kms_key_id           = lookup(var.s3_settings, "server_side_encryption_kms_key_id", null)
-      service_access_role_arn                     = lookup(var.s3_settings, "service_access_role_arn", null)
-      timestamp_column_name                       = lookup(var.s3_settings, "timestamp_column_name", null)
-      use_task_start_time_for_full_load_timestamp = lookup(var.s3_settings, "use_task_start_time_for_full_load_timestamp", null)
-      use_csv_no_sup_value                        = lookup(var.s3_settings, "use_csv_no_sup_value", null)
-    }
-  }
-
   tags = module.this.tags
 }

--- a/modules/dms-endpoint/variables.tf
+++ b/modules/dms-endpoint/variables.tf
@@ -132,9 +132,3 @@ variable "redshift_settings" {
   description = "Configuration block for Redshift settings"
   default     = null
 }
-
-variable "s3_settings" {
-  type        = map(any)
-  description = "Configuration block for S3 settings"
-  default     = null
-}

--- a/modules/dms-event-subscription/README.md
+++ b/modules/dms-event-subscription/README.md
@@ -176,37 +176,6 @@ module "s3_bucket" {
   context = module.this.context
 }
 
-module "dms_endpoint_s3_bucket" {
-  source = "cloudposse/dms/aws//modules/dms-endpoint"
-  # Cloud Posse recommends pinning every module to a specific version
-  # version     = "x.x.x"
-
-  endpoint_type = "target"
-  engine_name   = "s3"
-
-  s3_settings = {
-    bucket_name                      = module.s3_bucket.bucket_id
-    bucket_folder                    = null
-    cdc_inserts_only                 = false
-    csv_row_delimiter                = " "
-    csv_delimiter                    = ","
-    data_format                      = "parquet"
-    compression_type                 = "GZIP"
-    date_partition_delimiter         = "NONE"
-    date_partition_enabled           = true
-    date_partition_sequence          = "YYYYMMDD"
-    include_op_for_full_load         = true
-    parquet_timestamp_in_millisecond = true
-    timestamp_column_name            = "timestamp"
-    service_access_role_arn          = aws_iam_role.s3.arn
-  }
-
-  extra_connection_attributes = ""
-
-  attributes = ["target"]
-  context    = module.this.context
-}
-
 module "dms_replication_task" {
   source = "cloudposse/dms/aws//modules/dms-replication-task"
   # Cloud Posse recommends pinning every module to a specific version

--- a/modules/dms-replication-task/README.md
+++ b/modules/dms-replication-task/README.md
@@ -181,37 +181,6 @@ module "s3_bucket" {
   context = module.this.context
 }
 
-module "dms_endpoint_s3_bucket" {
-  source = "cloudposse/dms/aws//modules/dms-endpoint"
-  # Cloud Posse recommends pinning every module to a specific version
-  # version     = "x.x.x"
-
-  endpoint_type = "target"
-  engine_name   = "s3"
-
-  s3_settings = {
-    bucket_name                      = module.s3_bucket.bucket_id
-    bucket_folder                    = null
-    cdc_inserts_only                 = false
-    csv_row_delimiter                = " "
-    csv_delimiter                    = ","
-    data_format                      = "parquet"
-    compression_type                 = "GZIP"
-    date_partition_delimiter         = "NONE"
-    date_partition_enabled           = true
-    date_partition_sequence          = "YYYYMMDD"
-    include_op_for_full_load         = true
-    parquet_timestamp_in_millisecond = true
-    timestamp_column_name            = "timestamp"
-    service_access_role_arn          = aws_iam_role.s3.arn
-  }
-
-  extra_connection_attributes = ""
-
-  attributes = ["target"]
-  context    = module.this.context
-}
-
 module "dms_replication_task" {
   source = "cloudposse/dms/aws//modules/dms-replication-task"
   # Cloud Posse recommends pinning every module to a specific version


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Remove the `s3_settings` block & variable from the module

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Terraform has completely deprecated and remove s3_settings from the [aws_dms_endpoint resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint) and now any builds result in an error of:

```
Error: Unsupported block type
│ 
│   on .terraform/modules/dms-endpoint/main.tf line 118, in resource "aws_dms_endpoint" "default":
│  118:   dynamic "s3_settings" {
│ 
│ Blocks of type "s3_settings" are not expected here.
```

## references
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

Latest version showing that s3_settings is no longer there:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint

Previous version showing that it is there but should be removed from code because they will remove it themselves soon:
https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/dms_endpoint

> The s3_settings argument is deprecated, may not be maintained, and will be removed in a future version. Use the [aws_dms_s3_endpoint](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/dms_s3_endpoint) resource instead.
