### PR TITLE
add subnet_group_id optional override for subnet group id

### DIFF
--- a/modules/dms-replication-instance/main.tf
+++ b/modules/dms-replication-instance/main.tf
@@ -18,14 +18,14 @@ resource "aws_dms_replication_instance" "default" {
   preferred_maintenance_window = var.preferred_maintenance_window
   publicly_accessible          = var.publicly_accessible
   replication_instance_class   = var.replication_instance_class
-  replication_subnet_group_id  = join("", aws_dms_replication_subnet_group.default[*].id)
+  replication_subnet_group_id  = coalesce(var.subnet_group_id, join("", aws_dms_replication_subnet_group.default[*].id))
   vpc_security_group_ids       = var.vpc_security_group_ids
 
   tags = module.this.tags
 }
 
 resource "aws_dms_replication_subnet_group" "default" {
-  count = local.enabled ? 1 : 0
+  count = local.enabled && var.create_subnet_group ? 1 : 0
 
   replication_subnet_group_id          = module.this.id
   replication_subnet_group_description = format("%s DMS replication subnet group", module.this.id)

--- a/modules/dms-replication-instance/main.tf
+++ b/modules/dms-replication-instance/main.tf
@@ -1,5 +1,6 @@
 locals {
-  enabled = module.this.enabled
+  enabled             = module.this.enabled
+  create_subnet_group = local.enabled && var.subnet_group_id == null
 }
 
 resource "aws_dms_replication_instance" "default" {
@@ -25,7 +26,7 @@ resource "aws_dms_replication_instance" "default" {
 }
 
 resource "aws_dms_replication_subnet_group" "default" {
-  count = local.enabled && var.create_subnet_group ? 1 : 0
+  count = local.create_subnet_group ? 1 : 0
 
   replication_subnet_group_id          = module.this.id
   replication_subnet_group_description = format("%s DMS replication subnet group", module.this.id)

--- a/modules/dms-replication-instance/variables.tf
+++ b/modules/dms-replication-instance/variables.tf
@@ -72,3 +72,16 @@ variable "subnet_ids" {
   type        = list(string)
   description = "List of the EC2 subnet IDs for the replication subnet group"
 }
+
+variable "subnet_group_id" {
+  type        = string
+  description = "The human readable ID of the replication subnet group to be used with the replication instance"
+  default     = null
+}
+
+variable "create_subnet_group" {
+  type        = bool
+  description = "Whether to create a replication subnet group for the replication instance. If false, `subnet_group_id` must be provided"
+  default     = true
+
+}

--- a/modules/dms-replication-instance/variables.tf
+++ b/modules/dms-replication-instance/variables.tf
@@ -78,10 +78,3 @@ variable "subnet_group_id" {
   description = "The human readable ID of the replication subnet group to be used with the replication instance"
   default     = null
 }
-
-variable "create_subnet_group" {
-  type        = bool
-  description = "Whether to create a replication subnet group for the replication instance. If false, `subnet_group_id` must be provided"
-  default     = true
-
-}


### PR DESCRIPTION
## what
NOw if you provide a variable `subnet_group_id` to the terraform module, it will use that as the name of the subnet group that you create. This will allow multiple dms replication instances to use the same DMS subnet group.

## why

We need this functionality because AWS has limits on the number of DMS subnet groups that you can create. (It's 60) we have a very large volume of replications required in our system, and so we will hit that limit. We can always ask to have it continually increased, but all of these replication instances will be using the exact same subnet configuration and it's redundant to keep making the same configuration over and over again, and asking AWS to increase their limits.


## references
https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Limits.html#CHAP_Limits.Limits
