### PR TITLE
fix: terratest on examples/complete, outdated instance class & versions

### DIFF
--- a/examples/complete/aurora-postgres.tf
+++ b/examples/complete/aurora-postgres.tf
@@ -4,8 +4,8 @@ module "aurora_postgres_cluster" {
 
   engine                               = "aurora-postgresql"
   engine_mode                          = "provisioned"
-  engine_version                       = "15.4"
-  cluster_family                       = "aurora-postgresql15"
+  engine_version                       = "17.4"
+  cluster_family                       = "aurora-postgresql17"
   cluster_size                         = 1
   admin_user                           = var.admin_user
   admin_password                       = var.admin_password

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,8 +30,8 @@ module "dms_replication_instance" {
   source = "../../modules/dms-replication-instance"
 
   # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReleaseNotes.html
-  engine_version             = "3.5"
-  replication_instance_class = "dms.t2.small"
+  engine_version             = "3.6.1"
+  replication_instance_class = "dms.t3.small"
 
   allocated_storage            = 50
   apply_immediately            = true

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
     awsutils = {
       source  = "cloudposse/awsutils"

--- a/examples/complete/vpc.tf
+++ b/examples/complete/vpc.tf
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.3.0"
+  version = "2.4.2"
 
   availability_zones   = var.availability_zones
   vpc_id               = local.vpc_id


### PR DESCRIPTION
PR https://github.com/cloudposse/terraform-aws-dms/pull/43 is failing with tests.
```
Error: Unsupported argument
│ 
│   on .terraform/modules/subnets/main.tf line 286, in resource "aws_eip" "default":
│  286:   vpc = true
│ 
│ An argument named "vpc" is not expected here.
```

Updating the subnet module used in the examples/complete fixes this.


```
Error: Unsupported block type
│ 
│   on ../../modules/dms-endpoint/main.tf line 118, in resource "aws_dms_endpoint" "default":
│  118:   dynamic "s3_settings" {
│ 
│ Blocks of type "s3_settings" are not expected here.
```

Pin at v5 (only in the examples/complete) for now, as it'd be a heavy lift to deprecate the old settings. This is just so tests can pass.

Also update outdated instance classes and versions.